### PR TITLE
Removed blank line in Writer

### DIFF
--- a/mime.go
+++ b/mime.go
@@ -21,7 +21,6 @@ func writeMIMEHeader(w io.Writer, header textproto.MIMEHeader) error {
 			fmt.Fprintf(&b, "%s: %s\r\n", k, v)
 		}
 	}
-	fmt.Fprintf(&b, "\r\n")
 	_, err := io.Copy(w, &b)
 	return err
 }


### PR DESCRIPTION
Heya!🤲🏼

I use the library to encrypt multipart messages with PGP. During the development I noticed that the Thunderbird cannot parse the encrypted messages.
After a big search and a lot of time I noticed that the library writes a CRLF and then the content from the "cleartext" buffer. Since this can lead to big problems I removed the new line in the function "writeMIMEHeader", because the CRLF is not written into the buffer by me either!

I know this library is verry old, but would be great also for ther devs :)

Greetings from Germany!